### PR TITLE
Dereference nested objects

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -136,11 +136,21 @@ describe("merge", () => {
       expect(obj.propertyB).toBe("merged");
     });
 
-    it('dereferences nested objects even if there was no merge', () => {
-        const obj1 = { a: { z: 'z' } };
-        const dereferenced = merge(obj1, {});
-        expect(dereferenced).not.toBe(obj1);
-        expect(dereferenced.a).not.toBe(obj1.a);
+    it('dereferences nested objects even if merging with `undefined`', () => {
+      const obj1 = { a: { z: 'z' } };
+      const dereferenced = merge(obj1, {});
+      expect(dereferenced).not.toBe(obj1);
+      expect(dereferenced).toEqual(obj1);
+      expect(dereferenced.a).not.toBe(obj1.a);
+    });
+
+    it('dereferences nested objects if merging with non-object type', () => {
+      const obj1 = { a: 'z' };
+      const obj2 = { a: { z: 'z' } };
+      const dereferenced = merge(obj1, obj2);
+      expect(dereferenced.a).not.toBe(obj1.a);
+      expect(dereferenced.a).not.toBe(obj2.a);
+      expect(dereferenced).toEqual({ a: { z: 'z' } });
     });
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -135,6 +135,13 @@ describe("merge", () => {
       expect(obj.propertyA).toBe(namedObject.propertyA);
       expect(obj.propertyB).toBe("merged");
     });
+
+    it('dereferences nested objects even if there was no merge', () => {
+        const obj1 = { a: { z: 'z' } };
+        const dereferenced = merge(obj1, {});
+        expect(dereferenced).not.toBe(obj1);
+        expect(dereferenced.a).not.toBe(obj1.a);
+    });
   });
 
   describe("with options", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,10 @@ interface IObject {
 
 export const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
   objects.reduce((result, current) => {
+    if (current === undefined) {
+        return result;
+    }
+
     if (Array.isArray(current)) {
       throw new TypeError(
         "Arguments provided to ts-deepmerge must be objects, not arrays.",
@@ -69,7 +73,7 @@ export const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
               )
             : [...result[key], ...current[key]]
           : current[key];
-      } else if (isObject(result[key]) && isObject(current[key])) {
+      } else if (isObject(result[key]) || isObject(current[key])) {
         result[key] = merge(result[key] as IObject, current[key] as IObject);
       } else {
         result[key] =

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ interface IObject {
 export const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
   objects.reduce((result, current) => {
     if (current === undefined) {
-        return result;
+      return result;
     }
 
     if (Array.isArray(current)) {
@@ -73,8 +73,10 @@ export const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
               )
             : [...result[key], ...current[key]]
           : current[key];
-      } else if (isObject(result[key]) || isObject(current[key])) {
+      } else if (isObject(result[key]) && isObject(current[key])) {
         result[key] = merge(result[key] as IObject, current[key] as IObject);
+      } else if (!isObject(result[key]) && isObject(current[key])) {
+        result[key] = merge(current[key], undefined);
       } else {
         result[key] =
           current[key] === undefined


### PR DESCRIPTION
Ensures that nested objects are dereferenced even if the merge would not affect internal values.

e.g. if you have two objects:
```js
{ a: { z: 'z' }, b: 1 }
```
and
```js
{ b: 2 }
```

The output is still unchanged: `{ a: { z: 'z' }, b: 2 }` BUT the new `{ z: 'z' }` object is now dereferenced from the original. This improves consistency over the current implementation where if a deepmerge would alter an object the reference would be new, but if the object is untouched the reference is held.
