### PR TITLE
feat: allow to merge protected keys via specific merge option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
     }
 
     Object.keys(current).forEach((key) => {
-      if (["__proto__", "constructor", "prototype"].includes(key)) {
+      if (!merge.options.mergeProtectedKeys && ["__proto__", "constructor", "prototype"].includes(key)) {
         return;
       }
 
@@ -114,12 +114,19 @@ interface IOptions {
    * Default: `true`
    */
   uniqueArrayItems: boolean;
+
+  /**
+   * When `true` it will merge protected keys like `__proto__`, `constructor` and `prototype`,
+   * that would otherwise be ignored.
+   */
+  mergeProtectedKeys: boolean
 }
 
 const defaultOptions: IOptions = {
   allowUndefinedOverrides: true,
   mergeArrays: true,
   uniqueArrayItems: true,
+  mergeProtectedKeys: false,
 };
 
 merge.options = defaultOptions;


### PR DESCRIPTION
I have a domain object that merges domains together. The issue is that I also merge a `prototype` option, which gets stripped away because it's a protected key when placed inside a DOM node. Since I only work with simple objects, I can safely use the `prototype` key. 

I added a `mergeProtectedKeys` option that is disabled by default, so nothing changes unless a user specifically opts in.

```ts
import {merge} from "ts-deepmerge";

const a = {
    prototype: '',
}

const b = {
    prototype: 'test.com',
}

merge.withOptions(
    { mergeProtectedKeys: true },
    a,
    b,
)
```