### PR TITLE
fix: extend unsafe key blocklist to prevent Object.prototype method o…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,11 +60,23 @@ export const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
       );
     }
 
+    const UNSAFE_KEYS = new Set([
+      "__proto__",
+      "constructor",
+      "prototype",
+      "toString",
+      "valueOf",
+      "hasOwnProperty",
+      "isPrototypeOf",
+      "propertyIsEnumerable",
+      "toLocaleString",
+    ]);
+
     Object.keys(current).forEach((key) => {
-      if (["__proto__", "constructor", "prototype"].includes(key)) {
+      if (UNSAFE_KEYS.has(key)) {
         return;
       }
-
+  
       if (Array.isArray(result[key]) && Array.isArray(current[key])) {
         result[key] = merge.options.mergeArrays
           ? merge.options.uniqueArrayItems

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,19 @@ const isObject = (obj: any) => {
   return false;
 };
 
+const UNSAFE_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+  "toString",
+  "valueOf",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+]);
+
+
 interface IObject {
   [key: string]: any;
 }
@@ -59,18 +72,6 @@ export const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
         "Arguments provided to ts-deepmerge must be objects, not arrays.",
       );
     }
-
-    const UNSAFE_KEYS = new Set([
-      "__proto__",
-      "constructor",
-      "prototype",
-      "toString",
-      "valueOf",
-      "hasOwnProperty",
-      "isPrototypeOf",
-      "propertyIsEnumerable",
-      "toLocaleString",
-    ]);
 
     Object.keys(current).forEach((key) => {
       if (UNSAFE_KEYS.has(key)) {


### PR DESCRIPTION
…verrides

## Problem

The current blocklist only prevents prototype pollution via `__proto__`, `constructor`, and `prototype`. However, other built-in `Object.prototype` methods such as `toString` and `valueOf` can be overridden with non-function values, causing a `TypeError` whenever the merged object is used in a string context.

## Reproduction

```javascript
const { merge } = require('ts-deepmerge');

const userInput = JSON.parse('{"toString": "<img src=x onerror=alert(1)>"}');
const result = merge({ title: 'Hello' }, userInput);

console.log(typeof result.toString); // 'string' — no longer a function

`${result}`       // TypeError: Cannot convert object to primitive value
'' + result       // TypeError: Cannot convert object to primitive value
[result].join()   // TypeError: Cannot convert object to primitive value
```

This is a realistic scenario in applications that merge user-supplied JSON with server-side defaults (e.g. configuration objects, request body data).

## Fix

Moved the blocklist to a `Set` defined outside the `forEach` loop for efficiency, and extended it to include all `Object.prototype` methods that could cause unexpected behavior when overridden with non-function values.

## Methods added to blocklist

- `toString`
- `valueOf`
- `hasOwnProperty`
- `isPrototypeOf`
- `propertyIsEnumerable`
- `toLocaleString`

## Testing

Verified on Node.js v20.19.2 with ts-deepmerge 7.0.3:

```javascript
const { merge } = require('ts-deepmerge');

// Before fix: throws TypeError
// After fix: toString key is safely ignored
const result = merge({ title: 'Hello' }, { toString: 'hacked' });
console.log(result); // { title: 'Hello' }
console.log(`${result}`); // '[object Object]' — correct behavior restored
```